### PR TITLE
설정 화면 스크립션 수정

### DIFF
--- a/Code-Zero.xcodeproj/project.pbxproj
+++ b/Code-Zero.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		190448D027C79D56004E8A10 /* UserLoginData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190448CF27C79D56004E8A10 /* UserLoginData.swift */; };
 		190448DD27CB6274004E8A10 /* BottleWorldService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190448DC27CB6274004E8A10 /* BottleWorldService.swift */; };
 		190448DF27CB63EE004E8A10 /* BottleWorldUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190448DE27CB63EE004E8A10 /* BottleWorldUser.swift */; };
-		190448D027C79D56004E8A10 /* UserLoginData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190448CF27C79D56004E8A10 /* UserLoginData.swift */; };
 		1906C3F927C227140020185C /* AccountDeleteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1906C3F827C227140020185C /* AccountDeleteVC.swift */; };
 		1906C3FB27C239DD0020185C /* APITarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1906C3FA27C239DD0020185C /* APITarget.swift */; };
 		1906C3FD27C23BD20020185C /* MoyaLoggingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1906C3FC27C23BD20020185C /* MoyaLoggingPlugin.swift */; };
@@ -125,6 +125,8 @@
 		A2DC88D4271C122F0099438A /* Home.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2DC88D3271C122F0099438A /* Home.swift */; };
 		A2DC88D8271C12A90099438A /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2DC88D7271C12A90099438A /* NetworkResult.swift */; };
 		A2FC304E273695ED00B29296 /* Challenge.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A2FC304D273695ED00B29296 /* Challenge.storyboard */; };
+		D20A664B283DCC8700AB3E98 /* UserInfoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20A664A283DCC8700AB3E98 /* UserInfoService.swift */; };
+		D20A664D283DCCDF00AB3E98 /* SettingData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20A664C283DCCDF00AB3E98 /* SettingData.swift */; };
 		D256B8E82759EC57006D3CFD /* BottleWorldVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D256B8E72759EC57006D3CFD /* BottleWorldVC.swift */; };
 		D256B8F2275A0A1C006D3CFD /* BottleWorldListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D256B8F0275A0A1C006D3CFD /* BottleWorldListCell.swift */; };
 		D256B8F3275A0A1C006D3CFD /* BottleWorldListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D256B8F1275A0A1C006D3CFD /* BottleWorldListCell.xib */; };
@@ -148,9 +150,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		190448CF27C79D56004E8A10 /* UserLoginData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginData.swift; sourceTree = "<group>"; };
 		190448DC27CB6274004E8A10 /* BottleWorldService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleWorldService.swift; sourceTree = "<group>"; };
 		190448DE27CB63EE004E8A10 /* BottleWorldUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleWorldUser.swift; sourceTree = "<group>"; };
-		190448CF27C79D56004E8A10 /* UserLoginData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginData.swift; sourceTree = "<group>"; };
 		1906C3F827C227140020185C /* AccountDeleteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeleteVC.swift; sourceTree = "<group>"; };
 		1906C3FA27C239DD0020185C /* APITarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITarget.swift; sourceTree = "<group>"; };
 		1906C3FC27C23BD20020185C /* MoyaLoggingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaLoggingPlugin.swift; sourceTree = "<group>"; };
@@ -266,6 +268,8 @@
 		A2DC88D3271C122F0099438A /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
 		A2DC88D7271C12A90099438A /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		A2FC304D273695ED00B29296 /* Challenge.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Challenge.storyboard; sourceTree = "<group>"; };
+		D20A664A283DCC8700AB3E98 /* UserInfoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoService.swift; sourceTree = "<group>"; };
+		D20A664C283DCCDF00AB3E98 /* SettingData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingData.swift; sourceTree = "<group>"; };
 		D256B8E72759EC57006D3CFD /* BottleWorldVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleWorldVC.swift; sourceTree = "<group>"; };
 		D256B8F0275A0A1C006D3CFD /* BottleWorldListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleWorldListCell.swift; sourceTree = "<group>"; };
 		D256B8F1275A0A1C006D3CFD /* BottleWorldListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BottleWorldListCell.xib; sourceTree = "<group>"; };
@@ -725,6 +729,7 @@
 				6E1D337427C2B35000746CD5 /* Convenience.swift */,
 				6E1D337227C2B30C00746CD5 /* UserChallenge.swift */,
 				190448DE27CB63EE004E8A10 /* BottleWorldUser.swift */,
+				D20A664C283DCCDF00AB3E98 /* SettingData.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -735,11 +740,10 @@
 				A2DC88D7271C12A90099438A /* NetworkResult.swift */,
 				1906C3FA27C239DD0020185C /* APITarget.swift */,
 				1906C3FC27C23BD20020185C /* MoyaLoggingPlugin.swift */,
-				1906C40227C240270020185C /* UserNickService.swift */,
-				6E1D336E27C2AC9D00746CD5 /* ChallengeOpenService.swift */,
 				1906C40227C240270020185C /* UserLoginService.swift */,
-				6E1D336E27C2AC9D00746CD5 /* ChallengeOpenPreviewService.swift */,
+				6E1D336E27C2AC9D00746CD5 /* ChallengeOpenService.swift */,
 				190448DC27CB6274004E8A10 /* BottleWorldService.swift */,
+				D20A664A283DCC8700AB3E98 /* UserInfoService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -1030,6 +1034,7 @@
 				1933C68B274FD0D500E0842D /* ChallengeListView.swift in Sources */,
 				1923D91B27AFC94B00FE2C87 /* AccountPrivacyVC.swift in Sources */,
 				6E5B24B12748C8460071C9F2 /* UICollectionView+Extension.swift in Sources */,
+				D20A664D283DCCDF00AB3E98 /* SettingData.swift in Sources */,
 				A25C8BF4272E9E6500D2BA78 /* UITableView+Extension.swift in Sources */,
 				6EB97231275B3B0400AB8349 /* ChallengeOpenSecondStepView.swift in Sources */,
 				6EAD29EB2764EDF0004BAD6B /* ChallengeOpenStep.swift in Sources */,
@@ -1045,6 +1050,7 @@
 				191A4EA527650A41005D0525 /* FollowEmptyView.swift in Sources */,
 				A2DC88CF271C11D50099438A /* GenericResponse.swift in Sources */,
 				1933FE8C279FF50900BD0CA6 /* SettingVC.swift in Sources */,
+				D20A664B283DCC8700AB3E98 /* UserInfoService.swift in Sources */,
 				191A4EA8276652DB005D0525 /* UserListCell.swift in Sources */,
 				A29574DE273AB2570056CC93 /* ChallengeVC.swift in Sources */,
 				19DE9221273FD0FD001B0C30 /* ChallengeCalendarCell.swift in Sources */,

--- a/Code-Zero/Global/Model/SettingData.swift
+++ b/Code-Zero/Global/Model/SettingData.swift
@@ -1,0 +1,20 @@
+//
+//  UserData.swift
+//  Code-Zero
+//
+//  Created by Hailey on 2022/05/25.
+//
+
+import Foundation
+
+// MARK: - SettingData
+struct SettingData: Codable {
+    let user: UserInfo
+}
+
+// MARK: - UserInfo
+struct UserInfo: Codable {
+    let id: Int
+    let name: String
+    let isPrivate: Bool
+}

--- a/Code-Zero/Global/Service/APITarget.swift
+++ b/Code-Zero/Global/Service/APITarget.swift
@@ -24,6 +24,9 @@ enum APITarget {
         isFromToday: Bool,
         token: String
     )
+    
+    // 설정
+    case userInfo(token: String)
 }
 
 // MARK: TargetType Protocol 구현
@@ -44,6 +47,8 @@ extension APITarget: TargetType {
             return "/my-challenge/add"
         case .bottleWorldBrowse:
             return "/bottleworld/browse"
+        case .userInfo:
+            return "/user/setting"
         }
     }
 
@@ -52,7 +57,7 @@ extension APITarget: TargetType {
         switch self {
         case .userNick, .auth, .challengeOpen:
             return .post
-        case .challengeOpenPreview, .bottleWorldBrowse:
+        case .challengeOpenPreview, .bottleWorldBrowse, .userInfo:
             return .get
         }
     }
@@ -80,7 +85,7 @@ extension APITarget: TargetType {
             }
             return .requestParameters(parameters: ["keyword": keyword],
                                       encoding: URLEncoding.queryString)
-        case .challengeOpenPreview:
+        case .challengeOpenPreview, .userInfo:
             return .requestPlain
         case .challengeOpen(let convenienceString, let inconvenienceString, let isFromToday, _):
             return .requestParameters(parameters: ["convenienceString": convenienceString,
@@ -101,7 +106,8 @@ extension APITarget: TargetType {
         case .userNick(_, let token),
                 .challengeOpenPreview(let token),
                 .challengeOpen(_, _, _, let token),
-                .bottleWorldBrowse(let token, _):
+                .bottleWorldBrowse(let token, _),
+                .userInfo(let token):
             return ["Content-Type": "application/json",
                     "Authorization": token]
         default:

--- a/Code-Zero/Global/Service/APITarget.swift
+++ b/Code-Zero/Global/Service/APITarget.swift
@@ -24,7 +24,7 @@ enum APITarget {
         isFromToday: Bool,
         token: String
     )
-    
+
     // 설정
     case userInfo(token: String)
 }

--- a/Code-Zero/Global/Service/UserInfoService.swift
+++ b/Code-Zero/Global/Service/UserInfoService.swift
@@ -31,8 +31,10 @@ class UserInfoService {
                 }
             case .failure(let error):
                 // 에러 처리 부분
-                if error.errorCode == 500 {
+                guard let response = error.response else { return }
+                if response.statusCode == 500 {
                     completion(.networkFail)
+                    return
                 }
                 completion(.serverErr)
                 debugPrint(error)

--- a/Code-Zero/Global/Service/UserInfoService.swift
+++ b/Code-Zero/Global/Service/UserInfoService.swift
@@ -1,0 +1,42 @@
+//
+//  UserInfoService.swift
+//  Code-Zero
+//
+//  Created by Hailey on 2022/05/25.
+//
+
+import Foundation
+import Moya
+
+class UserInfoService {
+    static let shared = UserInfoService()
+    private lazy var service = MoyaProvider<APITarget>(plugins: [MoyaLoggingPlugin()])
+
+    public func requestLogin(token: String,
+                             completion: @escaping (NetworkResult<SettingData>) -> Void) {
+
+        service.request(APITarget.userInfo(token: token)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    let decoder = JSONDecoder()
+                    let body = try decoder.decode(
+                        GenericResponse<SettingData>.self,
+                        from: response.data
+                    )
+                    guard let data = body.data else { return }
+                    completion(.success(data))
+                } catch let error {
+                    debugPrint(error)
+                }
+            case .failure(let error):
+                // 에러 처리 부분
+                if error.errorCode == 500 {
+                    completion(.networkFail)
+                }
+                completion(.serverErr)
+                debugPrint(error)
+            }
+        }
+    }
+}

--- a/Code-Zero/Screen/Account/VC/AccountNickVC.swift
+++ b/Code-Zero/Screen/Account/VC/AccountNickVC.swift
@@ -28,8 +28,8 @@ class AccountNickVC: UIViewController {
     }
     @IBAction func deleteAccountButton(_ sender: UIButton) {
         // TODO: 알랏창으로 이동
-        guard let popUpVC =
-                storyboard?.instantiateViewController(identifier: "AccountDeleteVC") as? AccountDeleteVC else {return}
+        guard let popUpVC = storyboard?.instantiateViewController(identifier: "AccountDeleteVC")
+                as? AccountDeleteVC else { return }
         popUpVC.modalPresentationStyle = .overCurrentContext
         popUpVC.modalTransitionStyle = .crossDissolve
         self.present(popUpVC, animated: true, completion: nil)

--- a/Code-Zero/Screen/BottleWorld/View/UserListView.swift
+++ b/Code-Zero/Screen/BottleWorld/View/UserListView.swift
@@ -38,7 +38,7 @@ class UserListView: UIView {
             fetchBrowserData(keyword: filter)
         }
     }
-    var delegate: BottleWorldUsersDelegate?
+    weak var delegate: BottleWorldUsersDelegate?
 
     // MARK: - @IBOutlet
     @IBOutlet weak var userListTableView: UITableView!

--- a/Code-Zero/Screen/Calendar/VC/ChallengeTitleView.swift
+++ b/Code-Zero/Screen/Calendar/VC/ChallengeTitleView.swift
@@ -41,6 +41,6 @@ class ChallengeTitleView: UIView {
         challengeSubjectLabel.text = "편리함 | \(subject)"
         subjectView.backgroundColor = color
 
-        challengeSubjectLabel.setFontWith(font: .futuraStd(size: 14, family: .bold), in: ["|",subject])
+        challengeSubjectLabel.setFontWith(font: .futuraStd(size: 14, family: .bold), in: ["|", subject])
     }
 }

--- a/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
+++ b/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
@@ -248,6 +248,7 @@ extension ChallengeVC {
     private func fetchUserInfoData() {
         // swiftlint:disable line_length
         let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjAsImVtYWlsIjoieTR1cnRpam5makBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJuYW1lIjoi67SJ6rWs7Iqk67Cl66mNIiwiaWRGaXJlYmFzZSI6IkpoaW16VDdaUUxWcDhmakx3c1U5eWw1ZTNaeDIiLCJpYXQiOjE2NTM0ODk4MTAsImV4cCI6MTY1NjA4MTgxMCwiaXNzIjoiV1lCIn0.5oevdqhJA_NhURaD3-OOCwbUE92GvcXDndAFPW3vOHE"
+        // swiftlint:enable line_length
         UserInfoService.shared.requestLogin(token: token) { [weak self] result in
             switch result {
             case .success(let info):

--- a/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
+++ b/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
@@ -25,14 +25,14 @@ class ChallengeVC: UIViewController {
     }
 
     // MARK: - UI Components
-    private let menuButton: UIBarButtonItem = {
+    private lazy var alarmButton: UIBarButtonItem = {
         let button: UIButton = .init(type: .custom)
         button.frame = .init(x: 0, y: 0, width: 24, height: 24)
         button.setImage(UIImage(named: "icAlarm"), for: .normal)
         let barButtonItem = UIBarButtonItem(customView: button)
         return barButtonItem
     }()
-    private let alarmButton: UIBarButtonItem = {
+    private lazy var menuButton: UIBarButtonItem = {
         let button: UIButton = .init(type: .custom)
         button.frame = .init(x: 0, y: 0, width: 24, height: 24)
         button.setImage(UIImage(named: "icMenu"), for: .normal)

--- a/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
+++ b/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
@@ -36,6 +36,7 @@ class ChallengeVC: UIViewController {
         let button: UIButton = .init(type: .custom)
         button.frame = .init(x: 0, y: 0, width: 24, height: 24)
         button.setImage(UIImage(named: "icMenu"), for: .normal)
+        button.addTarget(self, action: #selector(menuButtonDidTap), for: .touchUpInside)
         let barButtonItem = UIBarButtonItem(customView: button)
         return barButtonItem
     }()
@@ -151,7 +152,7 @@ extension ChallengeVC {
         let space = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
         space.width = 8
         self.navigationItem.setRightBarButtonItems(
-            [alarmButton, space, menuButton],
+            [menuButton, space, alarmButton],
             animated: false
         )
     }
@@ -215,3 +216,23 @@ extension ChallengeVC {
         followingButton.isHidden = isMine
     }
 }
+
+// MARK: - Move Controller
+extension ChallengeVC {
+    @objc private func menuButtonDidTap() {
+        let storybard = UIStoryboard(name: "Setting", bundle: nil)
+        guard let settingVC = storybard.instantiateViewController(withIdentifier: "SettingVC") as? SettingVC else { return }
+        settingVC.userInfo = userInfo
+        navigationController?.pushViewController(settingVC, animated: true)
+    }
+    private func changeRootViewToHome() {
+        let storybard = UIStoryboard(name: "Home", bundle: nil)
+        let homeNavigationVC = storybard.instantiateViewController(withIdentifier: "Home")
+        UIApplication.shared.windows.first?.replaceRootViewController(
+            homeNavigationVC,
+            animated: true,
+            completion: nil
+        )
+    }
+}
+

--- a/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
+++ b/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
@@ -23,6 +23,7 @@ class ChallengeVC: UIViewController {
             updateSocialButtons(offset: selectedPersonIndex)
         }
     }
+    private var userInfo: UserInfo?
 
     // MARK: - UI Components
     private lazy var alarmButton: UIBarButtonItem = {
@@ -59,6 +60,11 @@ class ChallengeVC: UIViewController {
         highlightingFollowingListButton(offset: selectedPersonIndex)
         updateSocialButtons(offset: selectedPersonIndex)
     }
+    override func viewWillAppear(_ animated: Bool) {
+        navigationController?.isNavigationBarHidden = false
+        fetchUserInfoData()
+    }
+
     // MARK: - IBAction Method
 
     @IBAction func cheerUpButtonDidTap(_ sender: Any) {
@@ -236,3 +242,25 @@ extension ChallengeVC {
     }
 }
 
+// MARK: - Network
+extension ChallengeVC {
+    private func fetchUserInfoData() {
+        // swiftlint:disable line_length
+        let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjAsImVtYWlsIjoieTR1cnRpam5makBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJuYW1lIjoi7JWg7ZSM6rmA66-87Z2sIiwiaWRGaXJlYmFzZSI6IkpoaW16VDdaUUxWcDhmakx3c1U5eWw1ZTNaeDIiLCJpYXQiOjE2NDU5NDcwNzksImV4cCI6MTY0ODUzOTA3OSwiaXNzIjoiV1lCIn0.4c_MKEolk5Mv5GOjJbQxcAkwpJLyyOTX_fVptT_0sO4"
+        UserInfoService.shared.requestLogin(token: token) { [weak self] result in
+            switch result {
+            case .success(let info):
+                self?.userInfo = info.user
+                self?.nickNameLabel.text = info.user.name
+            case .requestErr(let error):
+                print(error)
+            case .serverErr:
+                // 토큰 만료(자동 로그아웃 느낌..)
+                self?.changeRootViewToHome()
+            case .networkFail:
+                // TODO: 서버 자체 에러 - 서버 점검 중 popup 제작?
+                break
+            }
+        }
+    }
+}

--- a/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
+++ b/Code-Zero/Screen/Challenge/VC/ChallengeVC.swift
@@ -227,7 +227,8 @@ extension ChallengeVC {
 extension ChallengeVC {
     @objc private func menuButtonDidTap() {
         let storybard = UIStoryboard(name: "Setting", bundle: nil)
-        guard let settingVC = storybard.instantiateViewController(withIdentifier: "SettingVC") as? SettingVC else { return }
+        guard let settingVC = storybard.instantiateViewController(withIdentifier: "SettingVC")
+                as? SettingVC else { return }
         settingVC.userInfo = userInfo
         navigationController?.pushViewController(settingVC, animated: true)
     }
@@ -246,7 +247,7 @@ extension ChallengeVC {
 extension ChallengeVC {
     private func fetchUserInfoData() {
         // swiftlint:disable line_length
-        let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjAsImVtYWlsIjoieTR1cnRpam5makBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJuYW1lIjoi7JWg7ZSM6rmA66-87Z2sIiwiaWRGaXJlYmFzZSI6IkpoaW16VDdaUUxWcDhmakx3c1U5eWw1ZTNaeDIiLCJpYXQiOjE2NDU5NDcwNzksImV4cCI6MTY0ODUzOTA3OSwiaXNzIjoiV1lCIn0.4c_MKEolk5Mv5GOjJbQxcAkwpJLyyOTX_fVptT_0sO4"
+        let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjAsImVtYWlsIjoieTR1cnRpam5makBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJuYW1lIjoi67SJ6rWs7Iqk67Cl66mNIiwiaWRGaXJlYmFzZSI6IkpoaW16VDdaUUxWcDhmakx3c1U5eWw1ZTNaeDIiLCJpYXQiOjE2NTM0ODk4MTAsImV4cCI6MTY1NjA4MTgxMCwiaXNzIjoiV1lCIn0.5oevdqhJA_NhURaD3-OOCwbUE92GvcXDndAFPW3vOHE"
         UserInfoService.shared.requestLogin(token: token) { [weak self] result in
             switch result {
             case .success(let info):

--- a/Code-Zero/Screen/ChallengeOpen/VC/ChallengeOpenVC.swift
+++ b/Code-Zero/Screen/ChallengeOpen/VC/ChallengeOpenVC.swift
@@ -73,7 +73,6 @@ class ChallengeOpenVC: UIViewController {
         userInputTextTuple.isTodayStart = thirdStepView.isTodayStart
     }
 
-
     // MARK: - IBAction Method
     @IBAction func nextButtonDidTap() {
         guard let nextStep = ChallengeOpenStep(rawValue: currentStep.rawValue + 1) else {

--- a/Code-Zero/Screen/Setting/Storyboard/Setting.storyboard
+++ b/Code-Zero/Screen/Setting/Storyboard/Setting.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kaG-Jw-tGS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kaG-Jw-tGS">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -33,6 +33,9 @@
                                         </constraints>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="Button" image="icXBlack24"/>
+                                        <connections>
+                                            <action selector="closeButtonDidTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="LE1-rg-5fs"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -50,36 +53,29 @@
                                     <constraint firstAttribute="height" constant="90" id="Nze-nl-00v"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bmd-NK-jM4">
-                                <rect key="frame" x="30" y="244" width="354" height="36"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="36" id="6Wp-n3-ta7"/>
-                                </constraints>
-                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kTz-Mb-Dc4">
-                                <rect key="frame" x="30" y="330" width="354" height="36"/>
+                                <rect key="frame" x="30" y="244" width="354" height="36"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="ZGR-oz-Bj8"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pkt-v0-z4n">
-                                <rect key="frame" x="30" y="416" width="354" height="36"/>
+                                <rect key="frame" x="30" y="330" width="354" height="36"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="hxW-HF-kcs"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cDy-U2-qrP">
-                                <rect key="frame" x="30" y="464" width="354" height="36"/>
+                                <rect key="frame" x="30" y="378" width="354" height="36"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="yJz-b4-gPX"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cGL-O3-vBY">
-                                <rect key="frame" x="30" y="512" width="354" height="36"/>
+                                <rect key="frame" x="30" y="426" width="354" height="36"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="36" id="H9Y-6W-nKg"/>
@@ -106,16 +102,13 @@
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="ZhU-VB-VbW" secondAttribute="bottom" constant="16" id="TYq-kS-zEs"/>
                             <constraint firstItem="fQA-4I-Eo6" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="Tg6-b9-mTO"/>
                             <constraint firstItem="tzJ-gt-aTA" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="UEd-nG-FhR"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="bmd-NK-jM4" secondAttribute="trailing" constant="30" id="WbC-Sw-Rnd"/>
-                            <constraint firstItem="bmd-NK-jM4" firstAttribute="top" secondItem="fQA-4I-Eo6" secondAttribute="bottom" constant="40" id="Z5u-R8-I4d"/>
-                            <constraint firstItem="kTz-Mb-Dc4" firstAttribute="top" secondItem="bmd-NK-jM4" secondAttribute="bottom" constant="50" id="aEW-7N-oz8"/>
+                            <constraint firstItem="kTz-Mb-Dc4" firstAttribute="top" secondItem="fQA-4I-Eo6" secondAttribute="bottom" constant="40" id="WE2-jT-CCa"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="tzJ-gt-aTA" secondAttribute="trailing" id="iwK-to-dTo"/>
                             <constraint firstItem="kTz-Mb-Dc4" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="jsE-lk-5Ek"/>
                             <constraint firstItem="fQA-4I-Eo6" firstAttribute="top" secondItem="tzJ-gt-aTA" secondAttribute="bottom" constant="20" id="kcz-DE-l3Q"/>
                             <constraint firstItem="pkt-v0-z4n" firstAttribute="top" secondItem="kTz-Mb-Dc4" secondAttribute="bottom" constant="50" id="nO2-fx-Y7f"/>
                             <constraint firstItem="pkt-v0-z4n" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="rnw-RR-RW7"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="fQA-4I-Eo6" secondAttribute="trailing" id="ufb-Vk-f5l"/>
-                            <constraint firstItem="bmd-NK-jM4" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="vr9-hW-R8j"/>
                             <constraint firstItem="cGL-O3-vBY" firstAttribute="top" secondItem="cDy-U2-qrP" secondAttribute="bottom" constant="12" id="yh8-aQ-xcE"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="cDy-U2-qrP" secondAttribute="trailing" constant="30" id="ykw-qm-ztT"/>
                         </constraints>
@@ -124,7 +117,6 @@
                     <connections>
                         <outlet property="userInfoView" destination="fQA-4I-Eo6" id="En3-i0-Dtf"/>
                         <outlet property="versionLabel" destination="ZhU-VB-VbW" id="ymX-e4-qzu"/>
-                        <outletCollection property="settingListView" destination="bmd-NK-jM4" collectionClass="NSMutableArray" id="oHB-tW-xG0"/>
                         <outletCollection property="settingListView" destination="kTz-Mb-Dc4" collectionClass="NSMutableArray" id="CLp-AD-hqA"/>
                         <outletCollection property="settingListView" destination="pkt-v0-z4n" collectionClass="NSMutableArray" id="eEN-wH-ZDk"/>
                         <outletCollection property="settingListView" destination="cDy-U2-qrP" collectionClass="NSMutableArray" id="LeM-Gb-ZCv"/>

--- a/Code-Zero/Screen/Setting/Storyboard/SettingLineView.xib
+++ b/Code-Zero/Screen/Setting/Storyboard/SettingLineView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/Code-Zero/Screen/Setting/Storyboard/UserView.xib
+++ b/Code-Zero/Screen/Setting/Storyboard/UserView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -18,8 +18,8 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="UserView" customModule="Code_Zero" customModuleProvider="target">
             <connections>
                 <outlet property="nickBackView" destination="f7e-iJ-pcw" id="8dR-q4-bSQ"/>
-                <outlet property="nickButton" destination="TWh-J2-vyx" id="ihx-08-AgK"/>
-                <outlet property="nickFirstLabel" destination="kUv-yx-Aac" id="O23-Na-XFM"/>
+                <outlet property="nickFirstLabel" destination="kUv-yx-Aac" id="vla-9N-T28"/>
+                <outlet property="nickLabel" destination="E1a-1K-Bcd" id="cMZ-Lf-PpW"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -47,25 +47,29 @@
                         <constraint firstAttribute="bottom" secondItem="kUv-yx-Aac" secondAttribute="bottom" id="fEd-2s-gc8"/>
                     </constraints>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TWh-J2-vyx">
-                    <rect key="frame" x="30" y="64" width="94" height="20"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="희영루루룰" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1a-1K-Bcd">
+                    <rect key="frame" x="30" y="64" width="74" height="19.5"/>
                     <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Bold" family="Spoqa Han Sans Neo" pointSize="16"/>
-                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                    <state key="normal" title="희영룰룰루" image="icArrowRightDark">
-                        <color key="titleColor" name="darkGray2"/>
-                    </state>
-                    <connections>
-                        <action selector="nickButtonDidTap:" destination="-1" eventType="touchUpInside" id="zvd-RI-SUb"/>
-                    </connections>
-                </button>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icArrowRightDark" translatesAutoresizingMaskIntoConstraints="NO" id="E9J-Cg-N01">
+                    <rect key="frame" x="108" y="62" width="20" height="20"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="20" id="GW4-tn-67y"/>
+                        <constraint firstAttribute="width" constant="20" id="QKv-TR-tKz"/>
+                    </constraints>
+                </imageView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
+                <constraint firstItem="E1a-1K-Bcd" firstAttribute="top" secondItem="f7e-iJ-pcw" secondAttribute="bottom" constant="16" id="3Yh-Kz-sRc"/>
+                <constraint firstItem="E9J-Cg-N01" firstAttribute="leading" secondItem="E1a-1K-Bcd" secondAttribute="trailing" constant="4" id="AO1-7l-7eI"/>
                 <constraint firstItem="f7e-iJ-pcw" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="HjQ-xd-ETF"/>
+                <constraint firstItem="E9J-Cg-N01" firstAttribute="top" secondItem="E1a-1K-Bcd" secondAttribute="top" constant="-2" id="THe-ah-GKq"/>
                 <constraint firstItem="f7e-iJ-pcw" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="30" id="aiC-W4-2bV"/>
-                <constraint firstItem="TWh-J2-vyx" firstAttribute="top" secondItem="f7e-iJ-pcw" secondAttribute="bottom" constant="16" id="tme-jO-nOF"/>
-                <constraint firstItem="TWh-J2-vyx" firstAttribute="leading" secondItem="kUv-yx-Aac" secondAttribute="leading" id="wYB-tq-AqN"/>
+                <constraint firstItem="E1a-1K-Bcd" firstAttribute="leading" secondItem="kUv-yx-Aac" secondAttribute="leading" id="zBf-8d-eAy"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="147.10144927536234" y="-169.75446428571428"/>

--- a/Code-Zero/Screen/Setting/VC/SettingVC.swift
+++ b/Code-Zero/Screen/Setting/VC/SettingVC.swift
@@ -92,7 +92,7 @@ extension SettingVC {
 
     @objc func touchUpToTOS() {
         let tosUrl: URL? =
-        NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        NSURL(string: "https://chatter-gallium-16e.notion.site/239ddeb527df483a89cdd2d8fe40fff3") as URL?
         guard let tosUrl = tosUrl else { return }
         let safariView: SFSafariViewController = SFSafariViewController(url: tosUrl)
         self.present(safariView, animated: true, completion: nil)
@@ -100,7 +100,7 @@ extension SettingVC {
 
     @objc func touchUpToPrivacyPolicy() {
         let privacyPolicyUrl: URL? =
-        NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        NSURL(string: "https://chatter-gallium-16e.notion.site/da60b412544b405aaeb8d4fefa46c5cb") as URL?
         guard let privacyPolicyUrl = privacyPolicyUrl else { return }
         let safariView: SFSafariViewController = SFSafariViewController(url: privacyPolicyUrl)
         self.present(safariView, animated: true, completion: nil)

--- a/Code-Zero/Screen/Setting/VC/SettingVC.swift
+++ b/Code-Zero/Screen/Setting/VC/SettingVC.swift
@@ -16,9 +16,10 @@ class SettingVC: UIViewController {
     @IBOutlet weak var versionLabel: UILabel!
 
     // MARK: - Property
-    let isUser: Bool = true
-    let settingListText = ["알림설정", "문의하기", "이용약관", "개인정보정책", "오픈소스"]
-
+    var isUser: Bool = true
+    let settingListText = ["문의하기", "이용약관", "개인정보정책", "오픈소스"]
+    var userInfo: UserInfo?
+    
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -71,5 +72,51 @@ extension SettingVC {
     func setAppVersion() {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
         versionLabel.text = "버전 \(version ?? "1.0.0")"
+    }
+    
+    @objc func touchUpToInsta() {
+        let instagramUrl: URL? = NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        guard let instagramUrl = instagramUrl else { return }
+        let safariView: SFSafariViewController = SFSafariViewController(url: instagramUrl)
+        present(safariView, animated: true, completion: nil)
+    }
+    
+    @objc func touchUpToTOS() {
+        let tosUrl: URL? = NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        guard let tosUrl = tosUrl else { return }
+        let safariView: SFSafariViewController = SFSafariViewController(url: tosUrl)
+        self.present(safariView, animated: true, completion: nil)
+    }
+    
+    @objc func touchUpToPrivacyPolicy() {
+        let privacyPolicyUrl: URL? = NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        guard let privacyPolicyUrl = privacyPolicyUrl else { return }
+        let safariView: SFSafariViewController = SFSafariViewController(url: privacyPolicyUrl)
+        self.present(safariView, animated: true, completion: nil)
+    }
+    
+    @objc func touchUpToOpenSource() {
+        let openSourceUrl: URL? = NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        guard let openSourceUrl = openSourceUrl else { return }
+        let safariView: SFSafariViewController = SFSafariViewController(url: openSourceUrl)
+        self.present(safariView, animated: true, completion: nil)
+    }
+    
+    func setListTouchGesture() {
+        let insta = UITapGestureRecognizer(target: self,
+                                           action: #selector(touchUpToInsta))
+        settingListView[0].addGestureRecognizer(insta)
+        
+        let tos = UITapGestureRecognizer(target: self,
+                                         action: #selector(touchUpToTOS))
+        settingListView[1].addGestureRecognizer(tos)
+        
+        let privatePolicy = UITapGestureRecognizer(target: self,
+                                                   action: #selector(touchUpToPrivacyPolicy))
+        settingListView[2].addGestureRecognizer(privatePolicy)
+        
+        let openSource = UITapGestureRecognizer(target: self,
+                                                   action: #selector(touchUpToPrivacyPolicy))
+        settingListView[3].addGestureRecognizer(openSource)
     }
 }

--- a/Code-Zero/Screen/Setting/VC/SettingVC.swift
+++ b/Code-Zero/Screen/Setting/VC/SettingVC.swift
@@ -83,35 +83,19 @@ extension SettingVC {
     }
 
     @objc func touchUpToInsta() {
-        let instagramUrl: URL? =
-        NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
-        guard let instagramUrl = instagramUrl else { return }
-        let safariView: SFSafariViewController = SFSafariViewController(url: instagramUrl)
-        present(safariView, animated: true, completion: nil)
+        presentSafariWebVC(url: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=")
     }
 
     @objc func touchUpToTOS() {
-        let tosUrl: URL? =
-        NSURL(string: "https://chatter-gallium-16e.notion.site/239ddeb527df483a89cdd2d8fe40fff3") as URL?
-        guard let tosUrl = tosUrl else { return }
-        let safariView: SFSafariViewController = SFSafariViewController(url: tosUrl)
-        self.present(safariView, animated: true, completion: nil)
+        presentSafariWebVC(url: "https://chatter-gallium-16e.notion.site/239ddeb527df483a89cdd2d8fe40fff3")
     }
 
     @objc func touchUpToPrivacyPolicy() {
-        let privacyPolicyUrl: URL? =
-        NSURL(string: "https://chatter-gallium-16e.notion.site/da60b412544b405aaeb8d4fefa46c5cb") as URL?
-        guard let privacyPolicyUrl = privacyPolicyUrl else { return }
-        let safariView: SFSafariViewController = SFSafariViewController(url: privacyPolicyUrl)
-        self.present(safariView, animated: true, completion: nil)
+        presentSafariWebVC(url: "https://chatter-gallium-16e.notion.site/da60b412544b405aaeb8d4fefa46c5cb")
     }
 
     @objc func touchUpToOpenSource() {
-        let openSourceUrl: URL? =
-        NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
-        guard let openSourceUrl = openSourceUrl else { return }
-        let safariView: SFSafariViewController = SFSafariViewController(url: openSourceUrl)
-        self.present(safariView, animated: true, completion: nil)
+        presentSafariWebVC(url: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=")
     }
 
     func setListTouchGesture() {

--- a/Code-Zero/Screen/Setting/VC/SettingVC.swift
+++ b/Code-Zero/Screen/Setting/VC/SettingVC.swift
@@ -7,14 +7,20 @@
 
 import UIKit
 import SnapKit
+import SafariServices
 
 class SettingVC: UIViewController {
-
+    
     // MARK: - IBOutlet
     @IBOutlet weak var userInfoView: UIView!
     @IBOutlet var settingListView: [UIView]!
     @IBOutlet weak var versionLabel: UILabel!
 
+    // MARK: - IBAction
+    @IBAction func closeButtonDidTap(_ sender: UIButton) {
+        self.navigationController?.popViewController(animated: true)
+    }
+    
     // MARK: - Property
     var isUser: Bool = true
     let settingListText = ["문의하기", "이용약관", "개인정보정책", "오픈소스"]
@@ -23,6 +29,7 @@ class SettingVC: UIViewController {
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.navigationController?.isNavigationBarHidden = true
         setUserInfoView()
         setSettingList()
         setAppVersion()
@@ -32,7 +39,9 @@ class SettingVC: UIViewController {
 // MARK: - Set View Info
 extension SettingVC {
     func setUserInfoView() {
-        if isUser {
+        switch isUser {
+        case true:
+            guard let userInfo = userInfo else { return }
             let isUserView = UserView(frame: CGRect(x: 0,
                                                     y: 0,
                                                     width: userInfoView.frame.width,
@@ -40,33 +49,32 @@ extension SettingVC {
             let navigationClosure: (UIViewController) -> Void = { view in
                 self.navigationController?.pushViewController(view, animated: true)
             }
-
+            
             userInfoView.addSubview(isUserView)
-            isUserView.setUserInfo(nick: "김미니미니")
+            isUserView.setUserInfo(nick: userInfo.name)
             isUserView.moveViewController = navigationClosure
-
-        } else {
+        case false:
             let isNotUserView = NotUserView(frame: CGRect(x: 0,
                                                           y: 0,
                                                           width: userInfoView.frame.width,
                                                           height: userInfoView.frame.height))
             userInfoView.addSubview(isNotUserView)
         }
-
+        
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
         versionLabel.text = "버전 \(version ?? "1.0.0")"
     }
-
+    
     func setSettingList() {
         settingListView.enumerated().forEach {
             let settingLineView = SettingLineView(frame: CGRect(x: 0,
                                                                 y: 0,
                                                                 width: self.view.frame.width - 60,
                                                                 height: $1.frame.height))
-
             $1.addSubview(settingLineView)
             settingLineView.settingLabel.text = settingListText[$0]
         }
+        setListTouchGesture()
     }
 
     func setAppVersion() {

--- a/Code-Zero/Screen/Setting/VC/SettingVC.swift
+++ b/Code-Zero/Screen/Setting/VC/SettingVC.swift
@@ -10,7 +10,7 @@ import SnapKit
 import SafariServices
 
 class SettingVC: UIViewController {
-    
+
     // MARK: - IBOutlet
     @IBOutlet weak var userInfoView: UIView!
     @IBOutlet var settingListView: [UIView]!
@@ -20,12 +20,12 @@ class SettingVC: UIViewController {
     @IBAction func closeButtonDidTap(_ sender: UIButton) {
         self.navigationController?.popViewController(animated: true)
     }
-    
+
     // MARK: - Property
     var isUser: Bool = true
     let settingListText = ["문의하기", "이용약관", "개인정보정책", "오픈소스"]
     var userInfo: UserInfo?
-    
+
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,7 +49,7 @@ extension SettingVC {
             let navigationClosure: (UIViewController) -> Void = { view in
                 self.navigationController?.pushViewController(view, animated: true)
             }
-            
+
             userInfoView.addSubview(isUserView)
             isUserView.setUserInfo(nick: userInfo.name)
             isUserView.moveViewController = navigationClosure
@@ -60,11 +60,11 @@ extension SettingVC {
                                                           height: userInfoView.frame.height))
             userInfoView.addSubview(isNotUserView)
         }
-        
+
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
         versionLabel.text = "버전 \(version ?? "1.0.0")"
     }
-    
+
     func setSettingList() {
         settingListView.enumerated().forEach {
             let settingLineView = SettingLineView(frame: CGRect(x: 0,
@@ -81,48 +81,52 @@ extension SettingVC {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")
         versionLabel.text = "버전 \(version ?? "1.0.0")"
     }
-    
+
     @objc func touchUpToInsta() {
-        let instagramUrl: URL? = NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        let instagramUrl: URL? =
+        NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
         guard let instagramUrl = instagramUrl else { return }
         let safariView: SFSafariViewController = SFSafariViewController(url: instagramUrl)
         present(safariView, animated: true, completion: nil)
     }
-    
+
     @objc func touchUpToTOS() {
-        let tosUrl: URL? = NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        let tosUrl: URL? =
+        NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
         guard let tosUrl = tosUrl else { return }
         let safariView: SFSafariViewController = SFSafariViewController(url: tosUrl)
         self.present(safariView, animated: true, completion: nil)
     }
-    
+
     @objc func touchUpToPrivacyPolicy() {
-        let privacyPolicyUrl: URL? = NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        let privacyPolicyUrl: URL? =
+        NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
         guard let privacyPolicyUrl = privacyPolicyUrl else { return }
         let safariView: SFSafariViewController = SFSafariViewController(url: privacyPolicyUrl)
         self.present(safariView, animated: true, completion: nil)
     }
-    
+
     @objc func touchUpToOpenSource() {
-        let openSourceUrl: URL? = NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
+        let openSourceUrl: URL? =
+        NSURL(string: "https://instagram.com/washyourbottle?igshid=YmMyMTA2M2Y=") as URL?
         guard let openSourceUrl = openSourceUrl else { return }
         let safariView: SFSafariViewController = SFSafariViewController(url: openSourceUrl)
         self.present(safariView, animated: true, completion: nil)
     }
-    
+
     func setListTouchGesture() {
         let insta = UITapGestureRecognizer(target: self,
                                            action: #selector(touchUpToInsta))
         settingListView[0].addGestureRecognizer(insta)
-        
-        let tos = UITapGestureRecognizer(target: self,
+
+        let tosList = UITapGestureRecognizer(target: self,
                                          action: #selector(touchUpToTOS))
-        settingListView[1].addGestureRecognizer(tos)
-        
+        settingListView[1].addGestureRecognizer(tosList)
+
         let privatePolicy = UITapGestureRecognizer(target: self,
                                                    action: #selector(touchUpToPrivacyPolicy))
         settingListView[2].addGestureRecognizer(privatePolicy)
-        
+
         let openSource = UITapGestureRecognizer(target: self,
                                                    action: #selector(touchUpToPrivacyPolicy))
         settingListView[3].addGestureRecognizer(openSource)

--- a/Code-Zero/Screen/Setting/VC/UserView.swift
+++ b/Code-Zero/Screen/Setting/VC/UserView.swift
@@ -15,15 +15,7 @@ class UserView: UIView {
     // MARK: - IBOutlet
     @IBOutlet weak var nickBackView: UIView!
     @IBOutlet weak var nickFirstLabel: UILabel!
-    @IBOutlet weak var nickButton: UIButton!
-
-    // MARK: - IBAction
-    @IBAction func nickButtonDidTap(_ sender: UIButton) {
-        guard let moveViewController = moveViewController else { return }
-        let storybard = UIStoryboard(name: "Account", bundle: nil)
-        let accountVC = storybard.instantiateViewController(withIdentifier: "AccountSettingVC")
-        moveViewController(accountVC)
-    }
+    @IBOutlet weak var nickLabel: UILabel!
 
     // MARK: - Override Function
     override init(frame: CGRect) {

--- a/Code-Zero/Screen/Setting/VC/UserView.swift
+++ b/Code-Zero/Screen/Setting/VC/UserView.swift
@@ -50,7 +50,14 @@ class UserView: UIView {
     }
 
     func setUserInfo(nick: String) {
-        nickButton.setTitle(nick, for: .normal)
-        nickFirstLabel.text = String(nick[nick.startIndex])
+        nickLabel.text = nick
+        let firstIndex = nick.index(nick.startIndex, offsetBy: 0)
+        let first = String(nick[firstIndex])
+        if first == "_" {
+            let secondIndex = nick.index(nick.startIndex, offsetBy: 1)
+            nickFirstLabel.text = String(nick[secondIndex])
+        } else {
+            nickFirstLabel.text = first
+        }
     }
 }

--- a/Code-Zero/Screen/Setting/VC/UserView.swift
+++ b/Code-Zero/Screen/Setting/VC/UserView.swift
@@ -45,6 +45,16 @@ class UserView: UIView {
         addSubview(view)
         nickBackView.setBorder(borderColor: .darkGray2, borderWidth: 1)
         nickBackView.makeRounded(cornerRadius: nil)
+        
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(moveAccountViewController))
+        view.addGestureRecognizer(gesture)
+    }
+    
+    @objc func moveAccountViewController() {
+        guard let moveViewController = moveViewController else { return }
+        let storybard = UIStoryboard(name: "Account", bundle: nil)
+        let accountVC = storybard.instantiateViewController(withIdentifier: "AccountSettingVC")
+        moveViewController(accountVC)
     }
 
     func setUserInfo(nick: String) {

--- a/Code-Zero/Screen/Setting/VC/UserView.swift
+++ b/Code-Zero/Screen/Setting/VC/UserView.swift
@@ -37,11 +37,11 @@ class UserView: UIView {
         addSubview(view)
         nickBackView.setBorder(borderColor: .darkGray2, borderWidth: 1)
         nickBackView.makeRounded(cornerRadius: nil)
-        
+
         let gesture = UITapGestureRecognizer(target: self, action: #selector(moveAccountViewController))
         view.addGestureRecognizer(gesture)
     }
-    
+
     @objc func moveAccountViewController() {
         guard let moveViewController = moveViewController else { return }
         let storybard = UIStoryboard(name: "Account", bundle: nil)

--- a/Code-Zero/Support/Info.plist
+++ b/Code-Zero/Support/Info.plist
@@ -25,7 +25,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>Setting</string>
+					<string>Challenge</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
## 🤗 What is this PR?
- 기획 스크립션 토대로 설정 화면 관련 수정
- issue: #66 

## 📸 Screenshot
<img width="250" src="https://user-images.githubusercontent.com/51286963/170308260-ad8fdcbc-2290-48c1-baa5-5050ec6ba3a8.png">


## ✅ Test Checklist
- [x] 설정 화면에서 닉네임 클릭 시 닉네임 설정 화면으로 이동하는데 기존에는 '닉네임 >' 부분만 터치가 가능했지만 위에 동그라미 프로필 이미지 부분도 클릭 시 이동할 수 있게 범위 수정
- [x] 챌린지 화면에서 햄버거 바로 설정화면 이동
- [x] 닉네임은 챌린지 화면에서 서버 통신으로 받아오기
- [x] 설정화면 이동 시 유저 정보 데이터 전달
- [x] 설정 화면 각 링크 연결

## 💬 Comment
- 설정 화면에서 맨 마지막 '오픈소스' 부분은 링크가 아직 없어서 인스타그램으로 넣어두었습니다!
- 챌린지 화면에서도 닉네임이 "누구누구's bottle" 부분에 필요해서 여기서 데이터 받아서 설정 화면으로 넘겨주는 방식을 택했는데 괜찮은지!
- UINavigationBarButton 이 lazy로 설정하지 않으면 action이 먹히지 않더라구~ 그래서 수정함!
- 내가 ChallengeVC 밑에 //MARK 달고 함수 추가했는데 맘에 안들면 변경해두 됩니다 'ㅅ'