### PR TITLE
닉네임 설정 api 연동

### DIFF
--- a/Code-Zero.xcodeproj/project.pbxproj
+++ b/Code-Zero.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		190448D027C79D56004E8A10 /* UserLoginData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190448CF27C79D56004E8A10 /* UserLoginData.swift */; };
 		190448DD27CB6274004E8A10 /* BottleWorldService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190448DC27CB6274004E8A10 /* BottleWorldService.swift */; };
 		190448DF27CB63EE004E8A10 /* BottleWorldUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190448DE27CB63EE004E8A10 /* BottleWorldUser.swift */; };
-		190448D027C79D56004E8A10 /* UserLoginData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 190448CF27C79D56004E8A10 /* UserLoginData.swift */; };
 		1906C3F927C227140020185C /* AccountDeleteVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1906C3F827C227140020185C /* AccountDeleteVC.swift */; };
 		1906C3FB27C239DD0020185C /* APITarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1906C3FA27C239DD0020185C /* APITarget.swift */; };
 		1906C3FD27C23BD20020185C /* MoyaLoggingPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1906C3FC27C23BD20020185C /* MoyaLoggingPlugin.swift */; };
@@ -40,6 +40,7 @@
 		1933FE9827A01D2300BD0CA6 /* SettingLineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1933FE9727A01D2300BD0CA6 /* SettingLineView.swift */; };
 		194251A7274A3694007E86B8 /* UICollectionView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 194251A6274A3694007E86B8 /* UICollectionView+Extension.swift */; };
 		19494259274FC5FB007CAD63 /* ChallengeListView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 19494258274FC5FB007CAD63 /* ChallengeListView.xib */; };
+		195A0F0427CCF266009F0FFD /* UserSettingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195A0F0327CCF266009F0FFD /* UserSettingService.swift */; };
 		195AC716275BCBC500BDECB6 /* Array+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195AC715275BCBC500BDECB6 /* Array+Extension.swift */; };
 		195AC718275BD5E500BDECB6 /* SwipeBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195AC717275BD5E500BDECB6 /* SwipeBarView.swift */; };
 		195AC71C275BD71F00BDECB6 /* TopTabBarCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 195AC71A275BD71F00BDECB6 /* TopTabBarCell.swift */; };
@@ -148,9 +149,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		190448CF27C79D56004E8A10 /* UserLoginData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginData.swift; sourceTree = "<group>"; };
 		190448DC27CB6274004E8A10 /* BottleWorldService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleWorldService.swift; sourceTree = "<group>"; };
 		190448DE27CB63EE004E8A10 /* BottleWorldUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleWorldUser.swift; sourceTree = "<group>"; };
-		190448CF27C79D56004E8A10 /* UserLoginData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginData.swift; sourceTree = "<group>"; };
 		1906C3F827C227140020185C /* AccountDeleteVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeleteVC.swift; sourceTree = "<group>"; };
 		1906C3FA27C239DD0020185C /* APITarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITarget.swift; sourceTree = "<group>"; };
 		1906C3FC27C23BD20020185C /* MoyaLoggingPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaLoggingPlugin.swift; sourceTree = "<group>"; };
@@ -179,6 +180,7 @@
 		1933FE9727A01D2300BD0CA6 /* SettingLineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingLineView.swift; sourceTree = "<group>"; };
 		194251A6274A3694007E86B8 /* UICollectionView+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Extension.swift"; sourceTree = "<group>"; };
 		19494258274FC5FB007CAD63 /* ChallengeListView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ChallengeListView.xib; sourceTree = "<group>"; };
+		195A0F0327CCF266009F0FFD /* UserSettingService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSettingService.swift; sourceTree = "<group>"; };
 		195AC715275BCBC500BDECB6 /* Array+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extension.swift"; sourceTree = "<group>"; };
 		195AC717275BD5E500BDECB6 /* SwipeBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeBarView.swift; sourceTree = "<group>"; };
 		195AC71A275BD71F00BDECB6 /* TopTabBarCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabBarCell.swift; sourceTree = "<group>"; };
@@ -735,11 +737,10 @@
 				A2DC88D7271C12A90099438A /* NetworkResult.swift */,
 				1906C3FA27C239DD0020185C /* APITarget.swift */,
 				1906C3FC27C23BD20020185C /* MoyaLoggingPlugin.swift */,
-				1906C40227C240270020185C /* UserNickService.swift */,
-				6E1D336E27C2AC9D00746CD5 /* ChallengeOpenService.swift */,
 				1906C40227C240270020185C /* UserLoginService.swift */,
-				6E1D336E27C2AC9D00746CD5 /* ChallengeOpenPreviewService.swift */,
+				6E1D336E27C2AC9D00746CD5 /* ChallengeOpenService.swift */,
 				190448DC27CB6274004E8A10 /* BottleWorldService.swift */,
+				195A0F0327CCF266009F0FFD /* UserSettingService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -1052,6 +1053,7 @@
 				6E6E4A5227B12E4200390493 /* ChallengeFinalVC.swift in Sources */,
 				A25C8BFA2731417800D2BA78 /* UILabel+Extension.swift in Sources */,
 				6E6C1E942751216C007488AD /* OptionCell.swift in Sources */,
+				195A0F0427CCF266009F0FFD /* UserSettingService.swift in Sources */,
 				6E5B24B8274D2C450071C9F2 /* EmptyChallengeCell.swift in Sources */,
 				19BF8DE527474BBD00776E1A /* JoinChallengeView.swift in Sources */,
 				6E1D337327C2B30C00746CD5 /* UserChallenge.swift in Sources */,

--- a/Code-Zero.xcodeproj/xcshareddata/xcschemes/Code-Zero.xcscheme
+++ b/Code-Zero.xcodeproj/xcshareddata/xcschemes/Code-Zero.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1330"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A2B7BDCC2714214300F1DB1F"
+               BuildableName = "Code-Zero.app"
+               BlueprintName = "Code-Zero"
+               ReferencedContainer = "container:Code-Zero.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A2B7BDCC2714214300F1DB1F"
+            BuildableName = "Code-Zero.app"
+            BlueprintName = "Code-Zero"
+            ReferencedContainer = "container:Code-Zero.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A2B7BDCC2714214300F1DB1F"
+            BuildableName = "Code-Zero.app"
+            BlueprintName = "Code-Zero"
+            ReferencedContainer = "container:Code-Zero.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Code-Zero/Global/Extension/UIViewController+Extension.swift
+++ b/Code-Zero/Global/Extension/UIViewController+Extension.swift
@@ -65,4 +65,15 @@ extension UIViewController {
         present(viewController, animated: true)
       }
     }
+
+    // 두번이상 navigation pop을 연속으로 하고 싶을 때 사용
+    func navigationPopBack(_ number: Int) {
+        if let viewControllers: [UIViewController] = navigationController?.viewControllers {
+            guard viewControllers.count < number else {
+                navigationController?.popToViewController(viewControllers[viewControllers.count - number],
+                                                               animated: true)
+                return
+            }
+        }
+    }
 }

--- a/Code-Zero/Global/Service/UserSettingService.swift
+++ b/Code-Zero/Global/Service/UserSettingService.swift
@@ -32,7 +32,9 @@ class UserSettingService {
                     debugPrint(error)
                 }
             case .failure(let error):
-                completion(.serverErr)
+                if error.response?.statusCode == 400 {
+                    completion(.requestErr("duplicateNick"))
+                }
                 debugPrint(error)
             }
         }

--- a/Code-Zero/Global/Service/UserSettingService.swift
+++ b/Code-Zero/Global/Service/UserSettingService.swift
@@ -1,0 +1,40 @@
+//
+//  UserSettingService.swift
+//  Code-Zero
+//
+//  Created by 미니 on 2022/02/28.
+//
+
+import Foundation
+import Moya
+
+class UserSettingService {
+    static let shared = UserSettingService()
+    private lazy var service = MoyaProvider<APITarget>(plugins: [MoyaLoggingPlugin()])
+
+    public func changeUserNick(
+        nick: String,
+        token: String,
+        completion: @escaping (NetworkResult<SimpleData>) -> Void
+    ) {
+        service.request(.userNick(nick: nick,
+                                  token: token)) { result in
+            switch result {
+            case .success(let response):
+                do {
+                    let decoder = JSONDecoder()
+                    let body = try decoder.decode(
+                        SimpleData.self,
+                        from: response.data
+                    )
+                    completion(.success(body))
+                } catch let error {
+                    debugPrint(error)
+                }
+            case .failure(let error):
+                completion(.serverErr)
+                debugPrint(error)
+            }
+        }
+    }
+}

--- a/Code-Zero/Global/Service/UserSettingService.swift
+++ b/Code-Zero/Global/Service/UserSettingService.swift
@@ -32,8 +32,14 @@ class UserSettingService {
                     debugPrint(error)
                 }
             case .failure(let error):
-                if error.response?.statusCode == 400 {
+                let errorCode = error.response?.statusCode
+                switch errorCode {
+                case 400:
                     completion(.requestErr("duplicateNick"))
+                case 500:
+                    completion(.networkFail)
+                default:
+                    completion(.serverErr)
                 }
                 debugPrint(error)
             }

--- a/Code-Zero/Screen/Account/Storyboard/Account.storyboard
+++ b/Code-Zero/Screen/Account/Storyboard/Account.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -221,20 +221,8 @@
                                     <constraint firstAttribute="height" constant="50" id="h2A-j3-jaL"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="계정" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wf9-b9-Dej">
-                                <rect key="frame" x="30" y="114" width="18.5" height="12"/>
-                                <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="10"/>
-                                <color key="textColor" name="gray3"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="khy1234@naver.com " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oJQ-gN-4r7">
-                                <rect key="frame" x="30" y="131" width="354" height="21"/>
-                                <fontDescription key="fontDescription" name="Futura-Bold" family="Futura" pointSize="16"/>
-                                <color key="textColor" name="gray2"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FU4-yA-oe0">
-                                <rect key="frame" x="30" y="172" width="354" height="57"/>
+                                <rect key="frame" x="30" y="114" width="354" height="57"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="닉네임" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Czf-K0-oiG">
                                         <rect key="frame" x="10" y="8" width="36" height="20"/>
@@ -300,7 +288,7 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="사용중" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vkO-Yq-nqg">
-                                <rect key="frame" x="30" y="241" width="33.5" height="14"/>
+                                <rect key="frame" x="30" y="183" width="33.5" height="14"/>
                                 <fontDescription key="fontDescription" name="SpoqaHanSansNeo-Medium" family="Spoqa Han Sans Neo" pointSize="12"/>
                                 <color key="textColor" name="redAlert"/>
                                 <nil key="highlightedColor"/>
@@ -309,30 +297,24 @@
                         <viewLayoutGuide key="safeArea" id="T9f-2z-396"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="Wf9-b9-Dej" firstAttribute="leading" secondItem="T9f-2z-396" secondAttribute="leading" constant="30" id="1Ta-7h-p98"/>
                             <constraint firstItem="vkO-Yq-nqg" firstAttribute="top" secondItem="FU4-yA-oe0" secondAttribute="bottom" constant="12" id="6Eg-xd-rm5"/>
                             <constraint firstItem="T9f-2z-396" firstAttribute="trailing" secondItem="FU4-yA-oe0" secondAttribute="trailing" constant="30" id="CCj-6x-hkF"/>
                             <constraint firstItem="vkO-Yq-nqg" firstAttribute="leading" secondItem="FU4-yA-oe0" secondAttribute="leading" id="Dlt-Y6-Kr9"/>
                             <constraint firstItem="jFK-uY-2la" firstAttribute="leading" secondItem="ETb-HN-XEQ" secondAttribute="trailing" constant="5" id="EqX-HP-qF2"/>
-                            <constraint firstItem="T9f-2z-396" firstAttribute="trailing" secondItem="oJQ-gN-4r7" secondAttribute="trailing" constant="30" id="Gbd-RT-BtH"/>
                             <constraint firstItem="ETb-HN-XEQ" firstAttribute="leading" secondItem="T9f-2z-396" secondAttribute="leading" constant="30" id="ImU-Xi-S5K"/>
                             <constraint firstItem="jFK-uY-2la" firstAttribute="top" secondItem="ETb-HN-XEQ" secondAttribute="top" id="K4m-Ok-qQH"/>
-                            <constraint firstItem="FU4-yA-oe0" firstAttribute="top" secondItem="oJQ-gN-4r7" secondAttribute="bottom" constant="20" id="Msa-Hh-0pK"/>
                             <constraint firstItem="ETb-HN-XEQ" firstAttribute="bottom" secondItem="4Gh-lv-qTz" secondAttribute="bottom" constant="-34" id="NBR-6d-tKP"/>
                             <constraint firstItem="jFK-uY-2la" firstAttribute="bottom" secondItem="ETb-HN-XEQ" secondAttribute="bottom" id="SFG-rr-Q8v"/>
-                            <constraint firstItem="oJQ-gN-4r7" firstAttribute="leading" secondItem="T9f-2z-396" secondAttribute="leading" constant="30" id="Xea-Cm-iuL"/>
                             <constraint firstItem="T9f-2z-396" firstAttribute="trailing" secondItem="Zbm-9d-3tn" secondAttribute="trailing" id="ePY-NC-xh3"/>
                             <constraint firstItem="FU4-yA-oe0" firstAttribute="leading" secondItem="T9f-2z-396" secondAttribute="leading" constant="30" id="fFy-iW-NUq"/>
                             <constraint firstItem="Zbm-9d-3tn" firstAttribute="leading" secondItem="4Gh-lv-qTz" secondAttribute="leading" id="fSQ-ng-v9d"/>
-                            <constraint firstItem="Wf9-b9-Dej" firstAttribute="top" secondItem="Zbm-9d-3tn" secondAttribute="bottom" constant="20" id="tDx-Bf-Doe"/>
+                            <constraint firstItem="FU4-yA-oe0" firstAttribute="top" secondItem="Zbm-9d-3tn" secondAttribute="bottom" constant="20" id="oeH-Bn-uTm"/>
                             <constraint firstItem="Zbm-9d-3tn" firstAttribute="top" secondItem="T9f-2z-396" secondAttribute="top" id="u4s-fD-PlY"/>
-                            <constraint firstItem="oJQ-gN-4r7" firstAttribute="top" secondItem="Wf9-b9-Dej" secondAttribute="bottom" constant="5" id="xgY-XG-dPv"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="duplicateCheckLabel" destination="vkO-Yq-nqg" id="ozy-l3-xNx"/>
                         <outlet property="editButton" destination="hJ9-2f-if3" id="3U9-1s-G43"/>
-                        <outlet property="emailLabel" destination="oJQ-gN-4r7" id="xVd-JO-nfR"/>
                         <outlet property="nickTextField" destination="yLz-MM-h1Y" id="bgE-bp-sX4"/>
                         <outlet property="nickView" destination="FU4-yA-oe0" id="TfX-zH-Lgs"/>
                     </connections>

--- a/Code-Zero/Screen/Account/VC/AccountNickVC.swift
+++ b/Code-Zero/Screen/Account/VC/AccountNickVC.swift
@@ -11,7 +11,6 @@ class AccountNickVC: UIViewController {
 
     // MARK: - IBOutlet
     @IBOutlet weak var nickView: UIView!
-    @IBOutlet weak var emailLabel: UILabel!
     @IBOutlet weak var nickTextField: UITextField!
     @IBOutlet weak var editButton: UIButton!
     @IBOutlet weak var duplicateCheckLabel: UILabel!
@@ -36,7 +35,6 @@ class AccountNickVC: UIViewController {
     }
 
     // MARK: - Property
-    var email: String?
     var nickname: String?
 
     // MARK: - View Life Cycle
@@ -53,7 +51,6 @@ class AccountNickVC: UIViewController {
 extension AccountNickVC {
     private func setLayout() {
         nickView.setBorder(borderColor: .gray2, borderWidth: 1)
-        if let email = email,
            let nickname = nickname {
             emailLabel.text = email
             nickTextField.text = nickname

--- a/Code-Zero/Screen/Account/VC/AccountNickVC.swift
+++ b/Code-Zero/Screen/Account/VC/AccountNickVC.swift
@@ -27,15 +27,15 @@ class AccountNickVC: UIViewController {
         changeRootViewToHome()
     }
     @IBAction func deleteAccountButton(_ sender: UIButton) {
-        guard let popUpVC =
-                storyboard?.instantiateViewController(identifier: "AccountDeleteVC") as? AccountDeleteVC else {return}
+        guard let popUpVC = storyboard?.instantiateViewController(identifier: "AccountDeleteVC")
+                as? AccountDeleteVC else { return }
         popUpVC.modalPresentationStyle = .overCurrentContext
         popUpVC.modalTransitionStyle = .crossDissolve
         self.present(popUpVC, animated: true, completion: nil)
     }
 
     // MARK: - Property
-    var nickname: String?
+    var originNickname: String?
 
     // MARK: - View Life Cycle
     override func viewDidLoad() {
@@ -51,11 +51,9 @@ class AccountNickVC: UIViewController {
 extension AccountNickVC {
     private func setLayout() {
         nickView.setBorder(borderColor: .gray2, borderWidth: 1)
-           let nickname = nickname {
-            emailLabel.text = email
+        if let nickname = originNickname {
             nickTextField.text = nickname
         } else {
-            emailLabel.text = "wash@your.bottle"
             nickTextField.text = "워시유어보틀"
         }
         duplicateCheckLabel.text = ""
@@ -68,10 +66,12 @@ extension AccountNickVC {
             self.view.endEditing(true)
             editButton.setImage(UIImage(named: "icEditOrange"), for: .normal)
             nickTextField.text = nickname
-        }
-        if nickname.count > 0 && nickname.count <= 5 {
+        } else if nickname == originNickname {
+            view.endEditing(true)
+            editButton.setImage(UIImage(named: "icEditOrange"), for: .normal)
+        } else if nickname.count > 0 && nickname.count <= 5 {
             // swiftlint:disable line_length
-            let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgsImVtYWlsIjoieHdvdWRAdGVzdC5jb20iLCJuYW1lIjoibWluaTMiLCJpZEZpcmViYXNlIjoidzZtblY4VklVU1hWY080Q0paVkNPTHowS2F1MiIsImlhdCI6MTY0NTM3NTM4MCwiZXhwIjoxNjQ3OTY3MzgwLCJpc3MiOiJXWUIifQ.JYS2amG9ydX_BeDCYDc93_cWDGhGOQ29Nq2CGW4SpZE"
+            let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjAsImVtYWlsIjoieTR1cnRpam5makBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJuYW1lIjoi67SJ6rWs7Iqk67Cl66mNIiwiaWRGaXJlYmFzZSI6IkpoaW16VDdaUUxWcDhmakx3c1U5eWw1ZTNaeDIiLCJpYXQiOjE2NTM1NzA0NTIsImV4cCI6MTY1NjE2MjQ1MiwiaXNzIjoiV1lCIn0.JOson17TpIuMlbL435hfW27pQnTbD8gNRMRjC8gA1So"
              // swiftlint:enable line_length
             requestUserNick(token: token, nick: nickname)
         }
@@ -95,7 +95,7 @@ extension AccountNickVC {
             case .success(let response):
                 if response.message == "유저 이름 세팅 성공" {
                     self?.view.endEditing(true)
-                    self?.nickname = nick
+                    self?.originNickname = nick
                     self?.editButton.setImage(UIImage(named: "icEditOrange"), for: .normal)
                 }
             case .requestErr(let error):
@@ -127,12 +127,10 @@ extension AccountNickVC: UITextFieldDelegate {
             }
         }
     }
-    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         editButtonDidTap(editButton)
         return true
     }
-    
     func textField(_ textField: UITextField,
                    shouldChangeCharactersIn range: NSRange,
                    replacementString string: String) -> Bool {

--- a/Code-Zero/Screen/Setting/Storyboard/NotUserView.xib
+++ b/Code-Zero/Screen/Setting/Storyboard/NotUserView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -39,6 +39,9 @@
                     <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                     <state key="normal" title="가입하기"/>
+                    <connections>
+                        <action selector="signUpButtonDidTap:" destination="-1" eventType="touchUpInside" id="etr-f3-1jw"/>
+                    </connections>
                 </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>

--- a/Code-Zero/Screen/Setting/Storyboard/Setting.storyboard
+++ b/Code-Zero/Screen/Setting/Storyboard/Setting.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kaG-Jw-tGS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kaG-Jw-tGS">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>

--- a/Code-Zero/Screen/Setting/VC/NotUserView.swift
+++ b/Code-Zero/Screen/Setting/VC/NotUserView.swift
@@ -9,6 +9,10 @@ import UIKit
 
 class NotUserView: UIView {
 
+    // MARK: - Property
+    var moveViewController: ((UIViewController) -> Void)?
+
+    // MARK: - override
     override init(frame: CGRect) {
         super.init(frame: frame)
         loadView()
@@ -18,6 +22,15 @@ class NotUserView: UIView {
         super.init(coder: coder)
     }
 
+    // MARK: - @IBAction
+    @IBAction func signUpButtonDidTap(_ sender: UIButton) {
+        guard let moveViewController = moveViewController else { return }
+        let storybard = UIStoryboard(name: "SignUp", bundle: nil)
+        let signInVC = storybard.instantiateViewController(withIdentifier: "SignInVC")
+        moveViewController(signInVC)
+    }
+
+    // MARK: - View Layout Style
     private func loadView() {
 
         guard let view = Bundle.main.loadNibNamed("NotUserView",

--- a/Code-Zero/Screen/Setting/VC/SettingVC.swift
+++ b/Code-Zero/Screen/Setting/VC/SettingVC.swift
@@ -16,7 +16,7 @@ class SettingVC: UIViewController {
     @IBOutlet weak var versionLabel: UILabel!
 
     // MARK: - Property
-    let isUser: Bool = true
+    let isUser: Bool = false
     let settingListText = ["알림설정", "문의하기", "이용약관", "개인정보정책", "오픈소스"]
 
     // MARK: - View Life Cycle
@@ -31,15 +31,14 @@ class SettingVC: UIViewController {
 // MARK: - Set View Info
 extension SettingVC {
     func setUserInfoView() {
+        let navigationClosure: (UIViewController) -> Void = { view in
+            self.navigationController?.pushViewController(view, animated: true)
+        }
         if isUser {
             let isUserView = UserView(frame: CGRect(x: 0,
                                                     y: 0,
                                                     width: userInfoView.frame.width,
                                                     height: userInfoView.frame.height))
-            let navigationClosure: (UIViewController) -> Void = { view in
-                self.navigationController?.pushViewController(view, animated: true)
-            }
-
             userInfoView.addSubview(isUserView)
             isUserView.setUserInfo(nick: "김미니미니", email: "xwoud@naver.com")
             isUserView.moveViewController = navigationClosure
@@ -50,6 +49,7 @@ extension SettingVC {
                                                           width: userInfoView.frame.width,
                                                           height: userInfoView.frame.height))
             userInfoView.addSubview(isNotUserView)
+            isNotUserView.moveViewController = navigationClosure
         }
 
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")

--- a/Code-Zero/Screen/Setting/VC/SettingVC.swift
+++ b/Code-Zero/Screen/Setting/VC/SettingVC.swift
@@ -16,7 +16,7 @@ class SettingVC: UIViewController {
     @IBOutlet weak var versionLabel: UILabel!
 
     // MARK: - Property
-    let isUser: Bool = false
+    let isUser: Bool = true
     let settingListText = ["알림설정", "문의하기", "이용약관", "개인정보정책", "오픈소스"]
 
     // MARK: - View Life Cycle

--- a/Code-Zero/Screen/SignUp/VC/NickSettingVC.swift
+++ b/Code-Zero/Screen/SignUp/VC/NickSettingVC.swift
@@ -16,7 +16,6 @@ class NickSettingVC: UIViewController {
     @IBOutlet weak var duplicateCheckLabel: UILabel!
 
     // MARK: - Property
-    var duplicateNick: [String] = ["민희", "주혁", "보틀월드"]
     lazy var accessoryView: UIView = {
         return UIView(frame: CGRect(x: 0.0,
                                     y: 0.0,
@@ -62,21 +61,6 @@ extension NickSettingVC {
         let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjAsImVtYWlsIjoieTR1cnRpam5makBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJuYW1lIjoi7JWg7ZSM6rmA66-87Z2sIiwiaWRGaXJlYmFzZSI6IkpoaW16VDdaUUxWcDhmakx3c1U5eWw1ZTNaeDIiLCJpYXQiOjE2NDU5NDcwNzksImV4cCI6MTY0ODUzOTA3OSwiaXNzIjoiV1lCIn0.4c_MKEolk5Mv5GOjJbQxcAkwpJLyyOTX_fVptT_0sO4"
         // swiftlint:enable line_length
         requestUserNick(token: token, nick: text)
-    }
-
-    func filterNickName(text: String) -> String? {
-        do {
-            let regex = try NSRegularExpression(pattern: "[가-힣ㄱ-ㅎㅏ-ㅣA-Za-z0-9_]")
-            let results = regex.matches(in: text,
-                                        range: NSRange(text.startIndex..., in: text))
-            return results.map {
-                String(text[Range($0.range, in: text)!])
-            }.joined(separator: "")
-
-        } catch let error {
-            print("invalid regex: \(error.localizedDescription)")
-            return nil
-        }
     }
 }
 
@@ -125,6 +109,7 @@ extension NickSettingVC: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        checkDuplicateNick()
         return true
     }
 

--- a/Code-Zero/Screen/SignUp/VC/NickSettingVC.swift
+++ b/Code-Zero/Screen/SignUp/VC/NickSettingVC.swift
@@ -58,12 +58,10 @@ extension NickSettingVC {
 
     @objc func checkDuplicateNick() {
         guard let text = nickTextField.text else { return }
-        guard duplicateNick.contains(text) else {
-            // 설정 페이지로 이동
-            return
-        }
-        duplicateCheckLabel.isHidden = false
-        duplicateCheckLabel.text = "이미 사용 중이에요! 다른 닉네임을 적어주세요"
+        // swiftlint:disable line_length
+        let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjAsImVtYWlsIjoieTR1cnRpam5makBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJuYW1lIjoi7JWg7ZSM6rmA66-87Z2sIiwiaWRGaXJlYmFzZSI6IkpoaW16VDdaUUxWcDhmakx3c1U5eWw1ZTNaeDIiLCJpYXQiOjE2NDU5NDcwNzksImV4cCI6MTY0ODUzOTA3OSwiaXNzIjoiV1lCIn0.4c_MKEolk5Mv5GOjJbQxcAkwpJLyyOTX_fVptT_0sO4"
+        // swiftlint:enable line_length
+        requestUserNick(token: token, nick: text)
     }
 
     func filterNickName(text: String) -> String? {
@@ -78,6 +76,30 @@ extension NickSettingVC {
         } catch let error {
             print("invalid regex: \(error.localizedDescription)")
             return nil
+        }
+    }
+}
+
+// MARK: - Network Function
+extension NickSettingVC {
+    private func requestUserNick(token: String, nick: String) {
+        UserSettingService.shared.changeUserNick(nick: nick,
+                                                 token: token) { [weak self] result in
+            switch result {
+            case .success(let response):
+                if response.message == "유저 이름 세팅 성공" {
+                    self?.navigationPopBack(3)
+                }
+            case .requestErr(let error):
+                if error == "duplicateNick" {
+                    self?.duplicateCheckLabel.isHidden = false
+                    self?.duplicateCheckLabel.text = "이미 사용 중이에요! 다른 닉네임을 적어주세요"
+                }
+            case .serverErr:
+                print("serverErr")
+            case .networkFail:
+                print("serverErr")
+            }
         }
     }
 }

--- a/Code-Zero/Screen/SignUp/VC/SignInVC.swift
+++ b/Code-Zero/Screen/SignUp/VC/SignInVC.swift
@@ -79,11 +79,7 @@ extension SignInVC {
     func moveNickSettingVC() {
         guard let nickSettingVC = storyboard?.instantiateViewController(withIdentifier: "NickSettingVC")
         else { return }
-        UIApplication.shared.windows.first?.replaceRootViewController(
-            nickSettingVC,
-            animated: true,
-            completion: nil
-        )
+        navigationController?.pushViewController(nickSettingVC, animated: true)
     }
 }
 // MARK: - ASAuthorizationControllerDelegate

--- a/Code-Zero/Support/Info.plist
+++ b/Code-Zero/Support/Info.plist
@@ -25,7 +25,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>BottleWorld</string>
+					<string>Setting</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
## 🤗 What is this PR?
- 설정/계정/계정관리 에서 닉네임 변경하는 api 연결
- issue: #51 

## 📸 Screenshot
<img width="250" alt="스크린샷 2022-05-26 오후 10 35 56" src="https://user-images.githubusercontent.com/51286963/170498507-ea181a1b-b04a-4479-932f-eb208f1a0707.png">

## ✅ Test Checklist
- [x] 설정 화면에서 닉네임 받아올 수 있게 수정
- [x] 체크 버튼 클릭 시 서버 연동

## 💬 Comment
- 이전에 pr한 #66 과 연동이 아직 되지 않아 설정 화면에서 기존 닉네임을 받아오는 코드가 없습니다 ! develop 으로 pr하고 수정할 것 입니다
- 기존 닉네임과 동일한 닉네임일 때 체크 버튼을 클릭 시 서버 연동 이뤄지지 않게 수정했습니다 -> 서버가 중복으로 처리하기 때문입니다
- 닉네임이 5글자 초과 시 안내 문구가 나오고, 7글자 초과 글자는 textfield에 작성되지 않습니다 !