### PR TITLE
챌린지 오픈 1단계 QA 이슈 수정

### DIFF
--- a/Code-Zero/Screen/ChallengeOpen/View/ChallengeOpenFirstStepView.swift
+++ b/Code-Zero/Screen/ChallengeOpen/View/ChallengeOpenFirstStepView.swift
@@ -26,6 +26,11 @@ class ChallengeOpenFirstStepView: LoadXibView, ChallengeOpenStepViewType {
         initView()
     }
 
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        convenientInputTextField.endEditing(false)
+    }
+
     // MARK: - IBAction
     @IBAction func convenientInputTextFieldEditingChanged(_ sender: UITextField) {
         guard let text = sender.text else {


### PR DESCRIPTION


## 🤗 What is this PR?

- 챌린지 오픈 1단계 QA 이슈 수정
- #91 
- 피그마 혹은 제플린 화면  
<img width="250" alt="스크린샷 2022-06-29 오전 12 44 29" src="https://user-images.githubusercontent.com/43847166/176222882-5323e056-8e68-4f2d-a6a6-203ee65d674f.png">

## ✅ Test Checklist

- [ ] 키패드 올라왔을 때 입력박스 바깥 영역 클릭하면 키패드 내려가야함

## 💬 Comment
X